### PR TITLE
chore: ignore .state level db folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.state


### PR DESCRIPTION
As its part of the runtime storage - the folder should be ignored by git.