### PR TITLE
fix: add missing ip package

### DIFF
--- a/bit.js
+++ b/bit.js
@@ -5,6 +5,7 @@ var filter
 var processor
 var working = false
 // Const
+const ip = require('ip')
 const BITCOIN_CONFIG = {
   rpc: {
     protocol: 'http',

--- a/index.js
+++ b/index.js
@@ -53,7 +53,6 @@ console.log("GENES = ", GENES)
 const Info = require('./info.js')
 const Bit = require('./bit.js')
 const Db = require('./db')
-const ip = require('ip')
 const daemon = {
   run: async function() {
     // 1. Initialize


### PR DESCRIPTION
`ip` unused in `index.js` but required in `bit.js` when no env var set